### PR TITLE
Add Debian 12, Ubuntu 24.04 LTS, and Fedora 42 distribution variants

### DIFF
--- a/Core/distro_manager.py
+++ b/Core/distro_manager.py
@@ -281,6 +281,32 @@ class DebianDistribution(TermuxDistribution):
 		return super().supports_architecture(termux_arch)
 
 
+class DebianBookwormDistribution(TermuxDistribution):
+	def get_name(self) -> str:
+		return "debian-12"
+
+	def _get_script_url(self) -> str:
+		return "https://raw.githubusercontent.com/termux/proot-distro/v4.26.0/distro-plugins/debian.sh"
+
+	def _map_architecture(self, arch: str) -> str:
+		termux_arch_map = {
+				'arm64': 'aarch64',
+				'arm': 'arm',
+				'x86_64': 'x86_64',
+				'x86': 'i686'
+        }
+		return termux_arch_map.get(arch, arch)
+
+	def get_display_info(self) -> Dict[str, Any]:
+		base_info = super().get_display_info()
+		base_info.update({
+				'name': 'Debian 12 (Bookworm)',
+				'description': 'Stable release for 32-bit devices.',
+				'source': 'Termux/proot-distro v4.26.0'
+		})
+		return base_info
+
+
 class UbuntuDistribution(TermuxDistribution):
 	def get_name(self) -> str:
 		return "ubuntu"
@@ -297,6 +323,31 @@ class UbuntuDistribution(TermuxDistribution):
 	def supports_architecture(self, arch: str) -> bool:
 		termux_arch = self._map_architecture(arch)
 		return super().supports_architecture(termux_arch)
+
+
+class UbuntuLTSDistribution(TermuxDistribution):
+	def get_name(self) -> str:
+		return "ubuntu-lts"
+
+	def _get_script_url(self) -> str:
+		return "https://raw.githubusercontent.com/termux/proot-distro/v4.29.0/distro-plugins/ubuntu.sh"
+
+	def _map_architecture(self, arch: str) -> str:
+		termux_arch_map = {
+				'arm64': 'aarch64',
+				'arm': 'arm',
+				'x86_64': 'x86_64'
+		}
+		return termux_arch_map.get(arch, arch)
+
+	def get_display_info(self) -> Dict[str, Any]:
+		base_info = super().get_display_info()
+		base_info.update({
+				'name': 'Ubuntu 24.04 LTS (Noble)',
+				'description': 'LTS release (Noble).',
+				'source': 'Termux/proot-distro v4.29.0'
+		})
+		return base_info
 
 
 class ArchLinuxDistribution(TermuxDistribution):
@@ -330,10 +381,34 @@ class FedoraDistribution(TermuxDistribution):
 			'x86_64': 'x86_64'
 		}
 		return termux_arch_map.get(arch, arch)
-
-	def supports_architecture(self, arch: str) -> bool:
+def supports_architecture(self, arch: str) -> bool:
 		termux_arch = self._map_architecture(arch)
 		return super().supports_architecture(termux_arch)
+
+
+class Fedora42Distribution(TermuxDistribution):
+	def get_name(self) -> str:
+		return "fedora-42"
+
+	def _get_script_url(self) -> str:
+		return "https://raw.githubusercontent.com/termux/proot-distro/v4.25.0/distro-plugins/fedora.sh"
+
+	def _map_architecture(self, arch: str) -> str:
+		termux_arch_map = {
+				'arm64': 'aarch64',
+				'x86_64': 'x86_64'
+		}
+		return termux_arch_map.get(arch, arch)
+
+	def get_display_info(self) -> Dict[str, Any]:
+		base_info = super().get_display_info()
+		base_info.update({
+				'name': 'Fedora 42',
+				'description': 'Version 42 (stable on Android 15+).',
+				'source': 'Termux/proot-distro v4.25.0'
+		})
+		return base_info
+
 
 class VoidDistribution(TermuxDistribution):
 	def get_name(self) -> str:
@@ -904,7 +979,10 @@ class DistributionManager:
 			"void",
 			"manjaro",
 			"chimera",
-			"opensuse"
+			"opensuse",
+			"debian-12",
+			"ubuntu-lts",
+			"fedora-42"
 		]
 		self.termux_distros_list = [
 			DebianDistribution,
@@ -914,7 +992,10 @@ class DistributionManager:
 			VoidDistribution,
 			ManjaroDistribution,
 			ChimeraDistribution,
-			OpenSUSE_Distribution
+			OpenSUSE_Distribution,
+			DebianBookwormDistribution,
+			UbuntuLTSDistribution,
+			Fedora42Distribution
 		]
 
 		self.distributions: Dict[str, Distribution] = self._initialize_distributions()

--- a/Core/distro_manager.py
+++ b/Core/distro_manager.py
@@ -103,6 +103,12 @@ class Distribution(ABC):
 class TermuxDistribution(Distribution):
 	"""Base class for Termux/proot-distro based distributions"""
 
+	def _get_script_url(self) -> str:
+		"""Return the URL of the distribution script.
+			Override this method to use a specific version."""
+		distro_name = self.get_name()
+		return f"https://raw.githubusercontent.com/termux/proot-distro/v4.38.0/distro-plugins/{distro_name}.sh"
+
 	def _load_distro_data(self) -> None:
 		"""Load distribution data from GitHub or cache"""
 		distro_name = self.get_name()
@@ -117,7 +123,7 @@ class TermuxDistribution(Distribution):
 		# Fetch from GitHub
 		try:
 			self.is_offline()
-			script_url = f"https://raw.githubusercontent.com/termux/proot-distro/v4.36.0/distro-plugins/{distro_name}.sh"
+			script_url = self._get_script_url()
 			response = self.session.get(script_url)
 			response.raise_for_status()
 

--- a/Core/distro_manager.py
+++ b/Core/distro_manager.py
@@ -311,6 +311,9 @@ class UbuntuDistribution(TermuxDistribution):
 	def get_name(self) -> str:
 		return "ubuntu"
 
+	def _get_script_url(self) -> str:
+		return "https://raw.githubusercontent.com/termux/proot-distro/v4.30.1/distro-plugins/ubuntu.sh"
+
 	def _map_architecture(self, arch: str) -> str:
 		"""Map standard architecture to Termux-specific names"""
 		termux_arch_map = {
@@ -381,10 +384,10 @@ class FedoraDistribution(TermuxDistribution):
 			'x86_64': 'x86_64'
 		}
 		return termux_arch_map.get(arch, arch)
-def supports_architecture(self, arch: str) -> bool:
+
+	def supports_architecture(self, arch: str) -> bool:
 		termux_arch = self._map_architecture(arch)
 		return super().supports_architecture(termux_arch)
-
 
 class Fedora42Distribution(TermuxDistribution):
 	def get_name(self) -> str:
@@ -408,7 +411,6 @@ class Fedora42Distribution(TermuxDistribution):
 				'source': 'Termux/proot-distro v4.25.0'
 		})
 		return base_info
-
 
 class VoidDistribution(TermuxDistribution):
 	def get_name(self) -> str:

--- a/main.py
+++ b/main.py
@@ -96,7 +96,10 @@ class AndroSH:
 							"void",
 							"manjaro",
 							"chimera",
-							"opensuse"
+							"opensuse",
+							"debian-12",
+							"ubuntu-lts",
+							"fedora-42"
 						]
 
 


### PR DESCRIPTION
This PR adds three new distribution variants to AndroSH, along with a refactor to make version pinning cleaner:

### Changes

1. **Refactor: extract `_get_script_url()` method** (`Update distro plugin script URL to v4.38.0`)

- Added `_get_script_url()` to `TermuxDistribution` base class

- Bumped default proot-distro version from _v4.36.0_ → _v4.38.0_

- Allows per-distro version pinning without duplicating fetch logic

2. **Add new distro options to the menu** (`Add new distros options to the list in main.py`)

- Added `debian-12`, `ubuntu-lts`, `fedora-42` to the distro selection menu

3. **Add the three distribution classes** (`Add Debian 12, Ubuntu 24.04 and Fedora 42 distributions`)

- **Debian 12 (Bookworm)** — `debian-12`, proot-distro `v4.26.0`, includes 32-bit arch support

- **Ubuntu 24.04 LTS (Noble Numbat)** — `ubuntu-lts`, proot-distro `v4.29.0`

- **Fedora 42** — `fedora-42`, proot-distro `v4.25.0`, noted as stable on Android 15+

4. **Fix Ubuntu plugin script**

- Pinned main `ubuntu` distro to proot-distro `v4.30.1` (avoids broken Ubuntu 25.10 in newer proot-distro releases)

### Why

- Users get access to newer stable distro releases (Debian 12, Ubuntu 24.04 LTS, Fedora 42)

- The main `ubuntu` entry was broken due to proot-distro shipping a non-working Ubuntu 25.10; pinning to `v4.30.1` restores a working Ubuntu 25.04

- The refactor makes future version bumps and per-distro pinning maintainable

### Testing

- All three new distros appear in the selection menu

- Existing distros continue to work (default URL bumped to `v4.38.0`)

- Ubuntu now fetches a working image via pinned `v4.30.1`