### PR TITLE
Add 30s timeout to distro metadata HTTP requests

### DIFF
--- a/Core/distro_manager.py
+++ b/Core/distro_manager.py
@@ -123,7 +123,7 @@ class TermuxDistribution(Distribution):
 		try:
 			self.is_offline()
 			script_url = self._get_script_url()
-			response = self.session.get(script_url)
+			response = self.session.get(script_url, timeout=30)
 			response.raise_for_status()
 
 			script_content = response.text
@@ -539,7 +539,7 @@ class AlpineDistribution(Distribution):
 				self.console.verbose(f"Loaded Alpine metadata for {alpine_arch} from cache")
 			else:
 				self.is_offline()
-				response = self.session.get(metadata_url)
+				response = self.session.get(metadata_url, timeout=30)
 				response.raise_for_status()
 				raw_metadata = yaml.safe_load(response.text)
 
@@ -808,7 +808,7 @@ class KaliNethunterDistribution(Distribution):
 
 		try:
 			self.is_offline()
-			response = self.session.get(self.base_url + "/")
+			response = self.session.get(self.base_url + "/", timeout=30)
 			response.raise_for_status()
 
 			self.file_sizes = self._parse_html_directory(response.text)
@@ -854,7 +854,7 @@ class KaliNethunterDistribution(Distribution):
 		self.console.verbose(f"Fetching checksums from: {checksum_url}")
 
 		try:
-			response = self.session.get(checksum_url)
+			response = self.session.get(checksum_url, timeout=30)
 			response.raise_for_status()
 
 			checksums = {}


### PR DESCRIPTION
Four GET calls on the shared requests session had no timeout, so a slow or unresponsive upstream server (GitHub raw, dl-cdn.alpinelinux.org, kali.download) would block indefinitely and the distribution install/listing flow would hang without any way to recover.

Lines changed in `Core/distro_manager.py`:
- Termux distro script fetch (`script_url`)
- Alpine metadata fetch (`metadata_url`)
- Kali directory listing (`self.base_url + "/"`)
- Kali SHA256SUMS checksum fetch (`checksum_url`)

Each now passes `timeout=30`, matching the 30s timeout already used by the file downloader (`Core/downloader.py`). This keeps the existing retry/backoff strategy intact while bounding the total wait on an unresponsive host.